### PR TITLE
chore: bump @types/chrome in templates to 0.0.263

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -1,7 +1,10 @@
 {
   "name": "vite-web-extension",
   "displayName": "Vite Web Extension",
-  "author": "@samrum/vite-plugin-web-extension",
+  "author": {
+    "name": "@samrum/vite-plugin-web-extension",
+    "email": "dev@rubenmedina.com"
+  },
   "version": "1.0.0",
   "description": "A @samrum/vite-plugin-web-extension web extension",
   "type": "module",
@@ -15,7 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "@samrum/vite-plugin-web-extension": "^5.0.0",
-    "@types/chrome": "^0.0.254",
+    "@types/chrome": "^0.0.263",
     "@types/webextension-polyfill": "^0.10.6",
     "vite": "^5.0.0",
     "web-ext": "^7.8.0"

--- a/template/base/package.json
+++ b/template/base/package.json
@@ -1,10 +1,7 @@
 {
   "name": "vite-web-extension",
   "displayName": "Vite Web Extension",
-  "author": {
-    "name": "@samrum/vite-plugin-web-extension",
-    "email": "dev@rubenmedina.com"
-  },
+  "author": "@samrum/vite-plugin-web-extension",
   "version": "1.0.0",
   "description": "A @samrum/vite-plugin-web-extension web extension",
   "type": "module",

--- a/template/config/manifestV2+3/src/manifest.js
+++ b/template/config/manifestV2+3/src/manifest.js
@@ -61,9 +61,6 @@ const ManifestV3 = {
 
 export function getManifest(manifestVersion) {
   const manifest = {
-    author: {
-      email: pkg.author.email,
-    },
     description: pkg.description,
     name: pkg.displayName ?? pkg.name,
     version: pkg.version,

--- a/template/config/manifestV2+3/src/manifest.js
+++ b/template/config/manifestV2+3/src/manifest.js
@@ -61,7 +61,9 @@ const ManifestV3 = {
 
 export function getManifest(manifestVersion) {
   const manifest = {
-    author: pkg.author,
+    author: {
+      email: pkg.author.email,
+    },
     description: pkg.description,
     name: pkg.displayName ?? pkg.name,
     version: pkg.version,

--- a/template/config/manifestV2/src/manifest.js
+++ b/template/config/manifestV2/src/manifest.js
@@ -42,9 +42,6 @@ const manifest = {
 
 export function getManifest() {
   return {
-    author: {
-      email: pkg.author.email,
-    },
     description: pkg.description,
     name: pkg.displayName ?? pkg.name,
     version: pkg.version,

--- a/template/config/manifestV2/src/manifest.js
+++ b/template/config/manifestV2/src/manifest.js
@@ -42,7 +42,9 @@ const manifest = {
 
 export function getManifest() {
   return {
-    author: pkg.author,
+    author: {
+      email: pkg.author.email,
+    },
     description: pkg.description,
     name: pkg.displayName ?? pkg.name,
     version: pkg.version,

--- a/template/config/manifestV3/src/manifest.js
+++ b/template/config/manifestV3/src/manifest.js
@@ -40,9 +40,6 @@ const manifest = {
 
 export function getManifest() {
   return {
-    author: {
-      email: pkg.author.email,
-    },
     description: pkg.description,
     name: pkg.displayName ?? pkg.name,
     version: pkg.version,

--- a/template/config/manifestV3/src/manifest.js
+++ b/template/config/manifestV3/src/manifest.js
@@ -40,7 +40,9 @@ const manifest = {
 
 export function getManifest() {
   return {
-    author: pkg.author,
+    author: {
+      email: pkg.author.email,
+    },
     description: pkg.description,
     name: pkg.displayName ?? pkg.name,
     version: pkg.version,


### PR DESCRIPTION
Prior to version `0.0.254`, the type of `ManifestBass["author"]` in `@types/chrome` was as follows:

```ts
// ...

export interface ManifestBase {
    // Required
    manifest_version: number;
    name: string;
    version: string;

    // Recommended
    default_locale?: string | undefined;
    description?: string | undefined;
    icons?: ManifestIcons | undefined;

    // Optional
    author?: string | undefined

    // ...
}
```

After version `0.0.254`(As of now, the latest version is `0.0.263`), the type of  `ManifestBass["author"]` in `@types/chrome` is as follows:

```ts
//  ...

export interface ManifestBase {
    // Required
    manifest_version: number;
    name: string;
    version: string;

    // Recommended
    default_locale?: string | undefined;
    description?: string | undefined;
    icons?: ManifestIcons | undefined;

    // Optional
    author?: {
        email: string;
    } | undefine

    // ...
}
```